### PR TITLE
Allow iPads to share Debug-Files (fix #13)

### DIFF
--- a/lib/libs/logging.dart
+++ b/lib/libs/logging.dart
@@ -362,7 +362,7 @@ class _LogViewPageState extends State<LogViewPage> {
                                 return path;
                               }
                               copyFile().then((path) async {
-                                await Share.shareXFiles([XFile(path, mimeType: "text/plain")]);
+                                await Share.shareXFiles([XFile(path, mimeType: "text/plain")], sharePositionOrigin: Rect.fromLTWH(0, 0, MediaQuery.of(context).size.width, MediaQuery.of(context).size.height / 2));
                                 return path;
                               }).then((path) => File(path).delete());
                               Navigator.pop(context);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.2.1+56
+version: 2.2.2+57
 
 environment:
   sdk: '^3.0.0'


### PR DESCRIPTION
Sollte #13 fixen, siehe Kommentar auf der Bug-Seite.