### PR TITLE
Add im- and export of preferences from/to a json-file

### DIFF
--- a/lib/build_vars.dart
+++ b/lib/build_vars.dart
@@ -49,5 +49,5 @@ const kDebugNotifData = bool.fromEnvironment("debug_notif_data", defaultValue: f
 /// sollen alle Änderungen an Login-Daten im Log aufgezeichnet werden
 const kCredsDebug = bool.fromEnvironment("creds_debug", defaultValue: false);
 
-/// standartmäßig gewählter Host für VLANT-LogUp (wenn leer = Knopf zum Hochladen wird ausgegraut) -> Verwendung als https://<host>
+/// standardmäßig gewählter Host für VLANT-LogUp (wenn leer = Knopf zum Hochladen wird ausgegraut) -> Verwendung als https://<host>
 const kBaseLogUpHost = String.fromEnvironment("logup_host") == "" ? null : String.fromEnvironment("logup_host");

--- a/lib/changelog.dart
+++ b/lib/changelog.dart
@@ -31,7 +31,7 @@ final versionChanges = {
   ),
   59: const CLEntry(
     title: "Klausurenanzeige hinzugefügt",
-    description: "In der persönlichen Stundenplanansicht werden jetzt für Schüler in Jahrgang 11 und 12 automatisch eingetragene Klausuren angezeigt. Dies kann in den Einstellungen angepasst werden."
+    description: "In der persönlichen Stundenplanansicht werden jetzt für Schüler in Jahrgang 11 und 12 automatisch eingetragene Klausuren angezeigt. Dies kann in den Einstellungen angepasst werden.",
   ),
   60: const CLEntry(
     title: "Letzte Raumverwendungen markiert",
@@ -47,7 +47,11 @@ final versionChanges = {
   ),
   72: CLEntry(
     title: "Navigationsenträge ausblendbar",
-    descGen: (sie) => "${sie ? "Sie können" : "Du kannst"} jetzt in den Einstellungen für bessere Übersichtlichkeit Einträge in der Seitenleiste ausblenden."
+    descGen: (sie) => "${sie ? "Sie können" : "Du kannst"} jetzt in den Einstellungen für bessere Übersichtlichkeit Einträge in der Seitenleiste ausblenden.",
+  ),
+  73: CLEntry(
+    title: "Einstellungen übertragbar",
+    descGen: (sie) => "${sie ? "Sie können jetzt Ihre" : "Du kannst jetzt Deine"} Einstellungen auf ein anderes Gerät übertragen.",
   ),
 };
 

--- a/lib/changelog.dart
+++ b/lib/changelog.dart
@@ -51,7 +51,7 @@ final versionChanges = {
   ),
   73: CLEntry(
     title: "Einstellungen übertragbar",
-    descGen: (sie) => "${sie ? "Sie können jetzt Ihre" : "Du kannst jetzt Deine"} Einstellungen auf ein anderes Gerät übertragen.",
+    descGen: (sie) => "${sie ? "Sie können jetzt Ihre" : "Du kannst jetzt deine"} Einstellungen auf ein anderes Gerät übertragen.",
   ),
 };
 

--- a/lib/libs/preferences.dart
+++ b/lib/libs/preferences.dart
@@ -31,21 +31,15 @@
 // Sie sollten eine Kopie der GNU General Public License zusammen mit
 // kepler_app erhalten haben. Wenn nicht, siehe <https://www.gnu.org/licenses/>.
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:enough_serialization/enough_serialization.dart';
 import 'package:flutter/material.dart';
 import 'package:kepler_app/build_vars.dart';
 import 'package:kepler_app/colors.dart';
 import 'package:kepler_app/libs/indiware.dart';
 import 'package:kepler_app/libs/state.dart';
-import 'package:kepler_app/libs/logging.dart';
 import 'package:kepler_app/main.dart';
 import 'package:kepler_app/navigation.dart';
 import 'package:kepler_app/tabs/home/home.dart';
-import 'package:share_plus/share_plus.dart';
-import 'package:file_picker/file_picker.dart';
 
 const prefsPrefKey = "user_preferences";
 
@@ -242,127 +236,17 @@ class Preferences extends SerializableObject with ChangeNotifier {
   bool loaded = false;
 
   Future<void> save() async {
-    sharedPreferences.setString(prefsPrefKey, _serialize());
+    sharedPreferences.setString(prefsPrefKey, serialize());
   }
-  String _serialize() => _serializer.serialize(this);
+  String serialize() => _serializer.serialize(this);
   void loadFromJson(String json) {
     _serializer.deserialize(json, this);
     loaded = true;
     _loggingEnabled = loggingEnabled;
   }
 
-  /// Prefs aus externer Datei laden
-  Future<String> loadFromExportJson(BuildContext context) async {
-    final sie = preferredPronoun == Pronoun.sie;
-    /// Datei-Auswahldialog
-    FilePickerResult? result = await FilePicker.platform.pickFiles();
-    /// Prüft, ob eine Datei ausgewählt wurde
-    if (result != null) {
-      File file = File(result.files.single.path!);
-      try {
-        var importJsonText = (await file.readAsString());
-        var importJson = jsonDecode(importJsonText);
-
-        if (importJson['prefs_version'] != prefsVersion) {
-          bool abort = false;
-          await showDialog(
-            context: context,
-            builder: (context) => AlertDialog(
-              title: const Text("Achtung!"),
-              content: Text("Die Version dieser App stimmt nicht mit der Version der Herkunftsapp der Datei überein. ${sie ? "Bitte aktualisieren Sie": "Bitte aktualisiere"} beide Apps und ${sie ? "versuchen Sie" : "versuche"} es erneut. Das Fortfahren kann zu Fehlern führen und ${sie ? "Sie sollten dies nur benutzen, wenn Sie wissen, was Sie tun!": "Du solltest dies nur benutzen, wenn Du weißt, was du tust!"}"),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: const Text("Trotzdem fortfahren"),
-                ),
-                TextButton(
-                  onPressed: () {
-                    Navigator.pop(context);
-                    abort = true;
-                  },
-                  child: const Text("Abbrechen"),
-                ),
-              ]
-            ),
-          );
-          if (abort) return "abort";
-        }
-        loadFromJson(importJson["prefs_json"].toString());
-        return "success";
-      } catch (e, s) {
-        logCatch("prefs_import", e, s);
-        return "import_error";
-      }
-    } else {
-      return "abort";
-    }
-  }
-
   Preferences() {
     objectCreators["time_to_next_plan"] = (_) => HMTime(14, 45);
     objectCreators["stuplan_names"] = (_) => <String>[];
-  }
-}
-
-Widget Function(BuildContext) sharePreferencesPageBuilder(String? data) =>
-        (context) => SharePreferencesPage(data!);
-class SharePreferencesPage extends StatefulWidget {
-  final String data;
-  const SharePreferencesPage(this.data, {super.key});
-  @override
-  State<SharePreferencesPage> createState() => _SharePreferencesPageState();
-}
-class _SharePreferencesPageState extends State<SharePreferencesPage> {
-  @override
-  Widget build(BuildContext context) {
-    String prefsJson = sharedPreferences.getString(prefsPrefKey) as String;
-    var exportJsonText = {
-      'prefs_version': prefsVersion,
-      'prefs_json': prefsJson,
-    };
-    var exportJson = jsonEncode(exportJsonText);
-    return Scaffold(
-      appBar: AppBar(title: const Text("Gespeicherte Einstellungen")),
-      body: Column(
-        children: [
-          ElevatedButton(
-            onPressed: () {
-              Share.shareXFiles(
-                  [XFile.fromData(utf8.encode(exportJson.toString()), mimeType: 'application/json')], fileNameOverrides: ['Kepler_App_Einstellungen_Export.json'],
-                  sharePositionOrigin: Rect.fromLTWH(
-                      0, 0,
-                      MediaQuery.of(this.context).size.width,
-                      MediaQuery.of(this.context).size.height / 2
-                  )
-              );
-            },
-            child: const Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Flexible(flex: 0, child: Text("Exportieren")),
-                Flexible(
-                  child: Padding(
-                    padding: EdgeInsets.only(left: 4),
-                    child: Icon(Icons.ios_share, size: 16),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Expanded(
-            child: SizedBox(
-              width: double.infinity,
-              child: SingleChildScrollView(
-                child: Padding(
-                  padding: const EdgeInsets.all(4),
-                  //child: Text(widget.data + (sharedPreferences.getString(prefsPrefKey) as String)),
-                  child: Text(exportJsonText.toString()),
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
   }
 }

--- a/lib/tabs/settings.dart
+++ b/lib/tabs/settings.dart
@@ -34,7 +34,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:kepler_app/build_vars.dart';
@@ -155,7 +154,7 @@ class _SettingsTabState extends State<SettingsTab> {
                 /// SettingsTile, was bei Tippen einfach etwas ausführt
                 SettingsTile.navigation(
                   onPressed: (context) {
-                    if (kDebugMode) {
+                    if (kDebugFeatures) {
                       Navigator.push(context, MaterialPageRoute(builder: sharePreferencesDebugPageBuilder()));
                     } else {
                       exportJson(context);

--- a/lib/tabs/settings.dart
+++ b/lib/tabs/settings.dart
@@ -39,6 +39,7 @@ import 'package:kepler_app/build_vars.dart';
 import 'package:kepler_app/colors.dart';
 import 'package:kepler_app/drawer.dart';
 import 'package:kepler_app/libs/custom_color_picker.dart';
+import 'package:kepler_app/libs/filesystem.dart' as fs;
 import 'package:kepler_app/libs/indiware.dart';
 import 'package:kepler_app/libs/lernsax.dart';
 import 'package:kepler_app/libs/notifications.dart';
@@ -149,6 +150,34 @@ class _SettingsTabState extends State<SettingsTab> {
                 ),
                 /// da der Benutzer hier nichts ändern kann, gibt es tatsächlich mal ein passendes vorgefertigtes
                 /// SettingsTile, was bei Tippen einfach etwas ausführt
+                SettingsTile.navigation(
+                  onPressed: (context) async {
+                    Navigator.push(context, MaterialPageRoute(builder: sharePreferencesPageBuilder(await fs.readFile(await stuPlanDataFilePath))));
+                  },
+                  title: const Text("Einstellungen exportieren"),
+                  description: const Text("um diese auf einem anderen Gerät benutzen zu können"),
+                ),
+                SettingsTile.navigation(
+                  onPressed: (context) {
+                    prefs.loadFromExportJson(context).then((result) {
+                      switch (result) {
+                        case 'success':
+                          setState(() {});
+                          showSnackBar(text: "Einstellungen erfolgreich importiert", duration: const Duration(seconds: 2));
+                          break;
+                        case 'abort':
+                          break;
+                        case 'import_error':
+                          showSnackBar(text: "Fehler beim Import", error: true, clear: true);
+                        default:
+                          /// sollte nicht eintreten können
+                          break;
+                      }
+                    });
+                  },
+                  title: const Text("Einstellungen importieren"),
+                  description: const Text("von einem anderen Gerät exportierte Einstellungen übernehmen"),
+                ),
                 SettingsTile.navigation(
                   title: Text.rich(
                     TextSpan(
@@ -377,7 +406,7 @@ class _SettingsTabState extends State<SettingsTab> {
                   title: const Text("🏳️‍🌈 Regenbogenmodus aktivieren"),
                   description: const Text("Farbe vieler Oberflächen wird zu Regenbogenanimation geändert"),
                   // enabled: userType != UserType.nobody,
-                )//,
+                ),
                 /*rainbowSwitchTile(
                   initialValue: prefs.aprilFoolsEnabled,
                   onToggle: (val) => prefs.aprilFoolsEnabled = val,
@@ -1018,15 +1047,12 @@ class _NavHideDialogState extends State<NavHideDialog> {
                 return ListTile(
                   title: Row(
                     children: [
-                      (data.label is Text) ? Text("${child ? " - " : ""}${(data.label as Text).data}") : (data.id == StuPlanPageIDs.yours) ? Text(" - Eigener Plan") : data.label,
                       Expanded(
-                        child: Align(
-                          alignment: Alignment.centerRight,
-                          child: IconButton.outlined(
-                            onPressed: (data.ignoreHiding == true || parentHidden || startpage) ? null : () => hidden ? prefs.removeHiddenNavID(data.id) : prefs.addHiddenNavID(data.id),
-                            icon: Icon((hidden || parentHidden) ? MdiIcons.eyeOff : MdiIcons.eye),
-                          ),
-                        ),
+                        child: (data.label is Text) ? Text("${child ? " - " : ""}${(data.label as Text).data}") : (data.id == StuPlanPageIDs.yours) ? Text(" - Eigener Plan") : data.label,
+                      ),
+                      IconButton.outlined(
+                        onPressed: (data.ignoreHiding == true || parentHidden || startpage) ? null : () => hidden ? prefs.removeHiddenNavID(data.id) : prefs.addHiddenNavID(data.id),
+                        icon: Icon((hidden || parentHidden) ? MdiIcons.eyeOff : MdiIcons.eye),
                       ),
                     ],
                   ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -185,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "16dc141db5a2ccc6520ebb6a2eb5945b1b09e95085c021d9f914f8ded7f1465c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.4"
   fixnum:
     dependency: transitive
     description:
@@ -310,6 +318,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.2.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "9b78450b89f059e96c9ebb355fa6b3df1d6b330436e0b885fb49594c41721398"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.23"
   flutter_secure_storage:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.8.1+72
+version: 2.9.0+73
 
 environment:
   sdk: '^3.0.0'
@@ -129,6 +129,7 @@ dependencies:
   # libs for calendar
   calendar_date_picker2: ^1.0.2
   rainbow_color: ^2.0.1
+  file_picker: ^8.1.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Export der prefs in eine json-Datei, um diese dann auf einem anderen Gerät importieren zu können.

Um möglichen Fehlern vorzubeugen wurde eine "Einstellungenversion" eingeführt, welche bei **jeder Änderung in der Implementierung der Preferences** (Hinzufügen, Entfernen, etc.) **erhöht werden muss.**
Sollten sich diese Versionsnummern zwischen App und importierter Datei unterscheiden, wird eine Warnmeldung angezeigt, welche aber auch die Möglichkeit des Fortfahrens anbietet. Befindet sich eine Preferences-ID in der Datei, welche nicht implementiert ist, wird diese ohne Fehler trotzdem importiert und bleibt für immer als Relikt in den sharedPreferences erhalten...
In der json werden nur Einstellungen aufgeführt, welche schon einmal verändert wurden. Alle anderen Einstellungen bleiben vom Import also unberührt. Fehler passieren also nur (soweit ich weiß), wenn die Datenstruktur verändert wurde.

Was den Programmierstil betrifft, bin ich nicht ganz sicher, ob das alles so optimal ist. (Du kannst ja nochmal drüberschauen)

Außerdem im Dialog für das Ausblenden der Navigationseinträge die Icons wieder richtig angeordnet (siehe Screenshots):
![Screenshot_20241210_192850](https://github.com/user-attachments/assets/857f8fcb-7141-4670-9de5-3ad2fcc57088)
![Screenshot_20241210_192637](https://github.com/user-attachments/assets/0ba5a8bb-c5f7-47ba-bbff-50cc2d1b01f9)

