### PR TITLE
Benutzer selbst Events hinzufügen lassen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,16 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+            </intent-filter>
+        </receiver>
     </application>
 
     <queries>
@@ -41,4 +51,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
+
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 </manifest>

--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/libs/custom_events.dart
+++ b/lib/libs/custom_events.dart
@@ -1,0 +1,59 @@
+import 'package:enough_serialization/enough_serialization.dart';
+
+class CustomEvent extends SerializableObject {
+  /// Titel des Events
+  String get title => attributes["title"];
+  set title(String val) => attributes["title"] = val;
+
+  /// Beschreibung
+  String get description => attributes["desc"];
+  set description(String val) => attributes["desc"] = val;
+
+  /// Startzeit, oder nur für Datum wenn an Schulstunden gebunden
+  DateTime get startTime => DateTime.parse(attributes["start"]);
+  set startTime(DateTime val) => attributes["start"] = val.toIso8601String();
+  /// Endzeit, nur erforderlich, wenn nicht an Schulstunden gebunden
+  DateTime? get endTime => (attributes.containsKey("end") && attributes["end"] != null) ? DateTime.parse(attributes["end"]) : null;
+  set endTime(DateTime? val) => attributes["end"] = val?.toIso8601String();
+
+  /// falls das Event an Schulstunden gebunden ist (start/endLesson != null), wird startTime als Datum verwendet (Zeit wird ignoriert)
+  int? get startLesson => attributes["start_l"];
+  set startLesson(int? val) => attributes["start_l"];
+  /// Endschulstunde, nur erforderlich, wenn an Schulstunden gebunden
+  int? get endLesson => attributes["end_l"];
+  set endLesson(int? val) => attributes["end_l"];
+
+  /// will der Ersteller davor benachrichtigt werden?
+  bool get notify => attributes["notif"];
+  set notify(bool val) => attributes["notif"] = val;
+
+  /// wenn ein Event mehrfach wiederholt wird, können alle erstellten Events eine zufällige ID hier zugewiesen 
+  /// bekommen, um dann z.B. alle zu löschen, wenn eins gelöscht wird (oder alle zu ändern)
+  int? get repeatId => attributes["rid"];
+  set repeatId(int? val) => attributes["rid"] = val;
+
+  CustomEvent({
+    required String title,
+    required String description,
+    required DateTime startTime,
+    DateTime? endTime,
+    int? startLesson,
+    int? endLesson,
+    required bool notify,
+    int? repeatId,
+  }) {
+    this.title = title;
+    this.description = description;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.startLesson = startLesson;
+    this.endLesson = endLesson;
+    this.notify = notify;
+    this.repeatId = repeatId;
+  }
+
+  @override
+  String toString() {
+    return 'CustomEvent{title: $title, description: $description, startTime: $startTime, endTime: $endTime, startLesson: $startLesson, endLesson: $endLesson, notify: $notify, repeatId: $repeatId}';
+  }
+}

--- a/lib/libs/custom_events.dart
+++ b/lib/libs/custom_events.dart
@@ -1,4 +1,15 @@
+import 'dart:developer' show log;
+
 import 'package:enough_serialization/enough_serialization.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:kepler_app/libs/filesystem.dart';
+import 'package:kepler_app/libs/logging.dart';
+import 'package:kepler_app/libs/state.dart';
+import 'package:synchronized/synchronized.dart';
+
+/// Speicherpfad für die Events
+Future<String> get customEventDataFilePath async => "${await userDataDirPath}/custom-events.json";
 
 class CustomEvent extends SerializableObject {
   /// Titel des Events
@@ -18,10 +29,10 @@ class CustomEvent extends SerializableObject {
 
   /// falls das Event an Schulstunden gebunden ist (start/endLesson != null), wird startTime als Datum verwendet (Zeit wird ignoriert)
   int? get startLesson => attributes["start_l"];
-  set startLesson(int? val) => attributes["start_l"];
+  set startLesson(int? val) => attributes["start_l"] = val;
   /// Endschulstunde, nur erforderlich, wenn an Schulstunden gebunden
   int? get endLesson => attributes["end_l"];
-  set endLesson(int? val) => attributes["end_l"];
+  set endLesson(int? val) => attributes["end_l"] = val;
 
   /// will der Ersteller davor benachrichtigt werden?
   bool get notify => attributes["notif"];
@@ -52,8 +63,135 @@ class CustomEvent extends SerializableObject {
     this.repeatId = repeatId;
   }
 
+  CustomEvent.empty();
+
   @override
   String toString() {
     return 'CustomEvent{title: $title, description: $description, startTime: $startTime, endTime: $endTime, startLesson: $startLesson, endLesson: $endLesson, notify: $notify, repeatId: $repeatId}';
+  }
+}
+
+class CustomEventManager extends SerializableObject with ChangeNotifier {
+  CustomEventManager() {
+    objectCreators["events"] = (_) => <CustomEvent>[];
+    objectCreators["events.value"] = (_) => CustomEvent.empty();
+  }
+
+  // List<CustomEvent> get events => attributes["events"] ?? [];
+  List<CustomEvent> get events => [
+    CustomEvent(title: "Test Event", description: "Hier könnte Werbung stehen?", startTime: DateTime.now(), startLesson: 2, notify: false),
+    CustomEvent(title: "keine Schule oder so", description: "sehr sehr viel Text der gar nicht mehr aufhört was ist denn hier los warum geht denn das immer weiter", startTime: DateTime.now(), startLesson: 2, notify: false),
+    CustomEvent(title: "Testere Eventere", description: "", startTime: DateTime.now(), startLesson: 2, notify: false),
+    CustomEvent(title: "Längeres Event", description: "mehrere Stunden", startTime: DateTime.now(), startLesson: 2, endLesson: 5, notify: false),
+    CustomEvent(title: "Testere Eventere", description: "", startTime: DateTime.now(), endTime: DateTime.now().add(const Duration(hours: 2)), notify: false),
+    CustomEvent(title: "Testere 2 Eventere: dbl fun, longer title than ever before", description: "das ist ein mehrstündiges direktes Event", startTime: DateTime.now().add(const Duration(minutes: -5, hours: -1)), endTime: DateTime.now().add(const Duration(minutes: -50)), notify: false),
+  ];
+  set events(List<CustomEvent> events) => _setSaveNotify("events", events);
+
+  void _setSaveNotify(String key, dynamic data) {
+    attributes[key] = data;
+    notifyListeners();
+    save();
+  }
+  
+  final _serializer = Serializer();
+  bool loaded = false;
+  final Lock _fileLock = Lock();
+  Future<void> save() async {
+    if (_fileLock.locked) log("The file lock for CustomEventManager (file: cache/custom-events.json) is still locked!!! This means waiting...");
+    _fileLock.synchronized(() async => await writeFile(await customEventDataFilePath, _serialize()));
+  }
+  String _serialize() => _serializer.serialize(this);
+  void loadFromJson(String json) {
+    try {
+      _serializer.deserialize(json, this);
+    } catch (e, s) {
+      log("Error while decoding json for CustomEventManager from file:", error: e, stackTrace: s);
+      logCatch("ce_data", e, s);
+      return;
+    }
+    loaded = true;
+  }
+}
+
+final _timeFormat = DateFormat("HH:mm");
+
+/// zeigt Event schön formatiert an (mit Dialog beim Antippen)
+class CustomEventDisplay extends StatelessWidget {
+  /// anzuzeigendes Event
+  final CustomEvent event;
+  /// Stunde des vorherigen Events (damit Text mit Stunde nur einmal vor mehreren Events in derselben Stunde
+  /// angezeigt wird)
+  final int? previousDisplayHour;
+  /// soll der Info-Dialog beim Antippen angezeigt werden?
+  final bool showInfoDialog;
+
+  const CustomEventDisplay(this.event, this.previousDisplayHour, {super.key, this.showInfoDialog = true});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTextStyle.merge(
+      style: const TextStyle(
+        fontSize: 18,
+        height: 0,
+      ),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        /// TODO: add event info dialog, with edit option
+        // onTap: (showInfoDialog)
+        //     ? () => showDialog(
+        //         context: context,
+        //         builder: (dialogCtx) => generateLessonInfoDialog(dialogCtx, lesson, subject, classNameToStrip, lastRoomUsageInDay))
+        //     : null,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (event.startLesson != null) Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: SizedBox(
+                width: 26,
+                child: (previousDisplayHour != event.startLesson || (event.endLesson != null && event.endLesson != event.startLesson))
+                    ? Text("${event.startLesson}${event.endLesson != null ? ".\n- " : ""}${event.endLesson ?? ""}. ")
+                    : const SizedBox.shrink(),
+              ),
+            ) else Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: Text(
+                "${_timeFormat.format(event.startTime)}${event.endTime != null ? "\nbis\n${_timeFormat.format(event.endTime!)}" : ""}",
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 15),
+              ),
+            ),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(right: 4),
+                        child: Icon(Icons.calendar_today, size: 14),
+                      ),
+                      Expanded(
+                        child: Text(
+                          event.title,
+                          style: TextStyle(fontWeight: FontWeight.w500, color: hasDarkTheme(context) ? Colors.blue.shade200 : Colors.blue.shade900),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (event.description != "") Text(
+                    event.description,
+                    style: TextStyle(fontSize: 15, color: hasDarkTheme(context) ? Colors.blue.shade200 : Colors.blue.shade900),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/libs/indiware.dart
+++ b/lib/libs/indiware.dart
@@ -99,6 +99,11 @@ class HMTime extends SerializableObject {
     hour = int.parse(timeString.split(':')[0]);
     minute = int.parse(timeString.split(':')[1]);
   }
+
+  HMTime.fromDateTime(DateTime dt) {
+    hour = dt.hour;
+    minute = dt.minute;
+  }
   
   @override
   String toString() {
@@ -113,6 +118,15 @@ class HMTime extends SerializableObject {
 
   @override
   int get hashCode => toString().hashCode;
+
+  int compareTo(HMTime other) {
+    if (hour != other.hour) {
+      return hour.compareTo(other.hour);
+    }
+    return minute.compareTo(other.minute);
+  }
+  bool operator <(HMTime other) => compareTo(other) < 0;
+  bool operator >(HMTime other) => compareTo(other) > 0;
 }
 
 /// Root-Objekt für Schülermobildaten

--- a/lib/libs/notifications.dart
+++ b/lib/libs/notifications.dart
@@ -187,6 +187,7 @@ NotificationDetails eventNotificationDetails() => NotificationDetails(
     "Erinnerung an Ereignisse",
     channelDescription: "Benachrichtigungen bei anstehenden Ereignissen",
     category: AndroidNotificationCategory.event,
+    importance: Importance.max,
   ),
   iOS: const DarwinNotificationDetails(
     threadIdentifier: eventNotificationKey,
@@ -212,6 +213,7 @@ Future<NotificationAppLaunchDetails?> getNotifLaunchInfo() async => flutterLocal
 Future<int?> scheduleNotification({required String title, required String body, required String notifKey, required DateTime when}) async {
   if (!_timezonesInitialised) return null;
   if (notifKey != eventNotificationKey) return null;
+  if (when.isBefore(DateTime.now())) return null;
   final nid = Random().nextInt(153000000);
   await flutterLocalNotificationsPlugin.zonedSchedule(
     nid,

--- a/lib/libs/preferences.dart
+++ b/lib/libs/preferences.dart
@@ -272,6 +272,10 @@ class Preferences extends SerializableObject with ChangeNotifier {
   bool get showYourPlanAddDropdown => attributes["show_yp_addrop"] ?? true;
   set showYourPlanAddDropdown(bool val) => setSaveNotify("show_yp_addrop", val);
 
+  /// soll die Möglichkeit zum Hinzufügen von Ereignissen auf der Seite "Dein Stundenplan" angezeigt werden?
+  bool get showYourPlanAddEvents => attributes["show_yp_addevt"] ?? true;
+  set showYourPlanAddEvents(bool val) => setSaveNotify("show_yp_addevt", val);
+
   /// Host für VLANT-LogUp
   String? get logUpHost => attributes["log_up_url"] ?? kBaseLogUpHost;
   set logUpHost(String? val) => setSaveNotify("log_up_url", val ?? kBaseLogUpHost);

--- a/lib/libs/preferences.dart
+++ b/lib/libs/preferences.dart
@@ -235,7 +235,14 @@ class Preferences extends SerializableObject with ChangeNotifier {
   set aprilFoolsEnabled(bool val) => setSaveNotify("aprilfools_enabled", val);
 
   /// IDs aller aktivierten Benachrichtigungen
-  List<String> get enabledNotifs => cast<String>(attributes["notif_enabled"])?.split(",") ?? [];
+  List<String> get enabledNotifs {
+    final str = cast<String>(attributes["notif_enabled"]);
+    if (str != null && str.isNotEmpty) {
+      return str.split(",");
+    } else {
+      return [];
+    }
+  }
   set enabledNotifs(List<String> val) => setSaveNotify("notif_enabled", val.join(","));
   void addEnabledNotif(String val) {
     if (enabledNotifs.contains(val)) return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -425,6 +425,7 @@ class _KeplerAppState extends State<KeplerApp> {
         case newsNotificationKey:
           startingNavPageIDs = [NewsPageIDs.main, NewsPageIDs.news];
           break;
+        case eventNotificationKey:
         case stuPlanNotificationKey:
           startingNavPageIDs = [StuPlanPageIDs.main, StuPlanPageIDs.yours];
           break;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,6 +45,7 @@ import 'package:kepler_app/drawer.dart';
 import 'package:kepler_app/info_screen.dart';
 import 'package:kepler_app/introduction.dart';
 import 'package:kepler_app/libs/checks.dart';
+import 'package:kepler_app/libs/custom_events.dart';
 import 'package:kepler_app/libs/indiware.dart';
 import 'package:kepler_app/libs/lernsax.dart';
 import 'package:kepler_app/libs/logging.dart';
@@ -75,6 +76,7 @@ final _credStore = CredentialStore();
 final _appState = AppState();
 final _stuPlanData = StuPlanData();
 final _lernSaxData = LernSaxData();
+final _eventManager = CustomEventManager();
 
 /// global, damit nicht jede Seite sich selbst um Konfetti kümmern muss
 final ConfettiController globalConfettiController = ConfettiController();
@@ -113,6 +115,11 @@ Future<void> initializeApp() async {
   if (await fs.fileExists(await lernSaxDataFilePath)) {
     final data = await fs.readFile(await lernSaxDataFilePath);
     if (data != null) _lernSaxData.loadFromJson(data);
+  }
+  // in Datei gespeichert (CustomEventsManager)
+  if (await fs.fileExists(await customEventDataFilePath)) {
+    final data = await fs.readFile(await customEventDataFilePath);
+    if (data != null) _eventManager.loadFromJson(data);
   }
 
   /// Bei iOS werden die Credentials auch nach Deinstallation der App noch in der System-Keychain gespeichert, was
@@ -577,6 +584,9 @@ class _KeplerAppState extends State<KeplerApp> {
             ),
             ChangeNotifierProvider(
               create: (_) => _lernSaxData,
+            ),
+            ChangeNotifierProvider(
+              create: (_) => _eventManager,
             ),
           ],
           child: MaterialApp(

--- a/lib/tabs/hourtable/pages/plan_display.dart
+++ b/lib/tabs/hourtable/pages/plan_display.dart
@@ -32,7 +32,6 @@
 // kepler_app erhalten haben. Wenn nicht, siehe <https://www.gnu.org/licenses/>.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -52,7 +51,6 @@ import 'package:kepler_app/tabs/hourtable/pages/free_rooms.dart';
 import 'package:kepler_app/tabs/hourtable/pages/your_plan.dart'
     show generateExamInfoDialog, generateLessonInfoDialog;
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
 /// wie viel soll die Stundenplan-Liste weiter scrollbar sein, als echt nötig wäre - für "Ereignis hinzufügen"-Knopf
@@ -829,7 +827,7 @@ class _StuPlanDayDisplayState extends State<StuPlanDayDisplay> {
                       ),
                     ),
                     ConstrainedBox(
-                      constraints: BoxConstraints(maxHeight: MediaQuery.sizeOf(context).height * .2),
+                      constraints: BoxConstraints(maxHeight: MediaQuery.sizeOf(context).height * .1),
                       child: ListView.separated(
                         shrinkWrap: true,
                         itemCount: exams!.length,
@@ -1271,19 +1269,6 @@ class SPListContainer extends StatelessWidget {
                                   onPressed: () async {
                                     final event = await showModifyEventDialog(context, addEventSelectedDate ?? DateTime.now());
                                     if (event != null) {
-                                      if (event.shouldNotify && Platform.isAndroid && !(await Permission.scheduleExactAlarm.isGranted)) {
-                                        if (!context.mounted) return;
-                                        await showDialog(context: context, builder: (ctx) => AlertDialog(
-                                          title: Text("Pünktliche Benachrichtigungen"),
-                                          content: Selector<Preferences, bool>(
-                                            selector: (ctx, prefs) => prefs.preferredPronoun == Pronoun.sie,
-                                            builder: (ctx, sie, _) => Text("${sie ? "Sie verwenden" : "Du verwendest"} eine moderne Version von Android. Um die Erinnerung pünktlich anzeigen zu können, benötigt die App die Berechtigung dafür. Bitte ${sie ? "stimmen Sie" : "stimme"} dafür im folgenden Dialog zu."),
-                                          ),
-                                          actions: [
-                                            TextButton(onPressed: () => Navigator.pop(ctx), child: Text("Abschließen")),
-                                          ],
-                                        ));
-                                      }
                                       if (!context.mounted) return;
                                       Provider.of<CustomEventManager>(context, listen: false).addEvent(event);
                                     }

--- a/lib/tabs/hourtable/pages/plan_display.dart
+++ b/lib/tabs/hourtable/pages/plan_display.dart
@@ -38,6 +38,7 @@ import 'package:intl/intl.dart';
 import 'package:kepler_app/build_vars.dart';
 import 'package:kepler_app/colors.dart';
 import 'package:kepler_app/libs/checks.dart';
+import 'package:kepler_app/libs/custom_events.dart';
 import 'package:kepler_app/libs/indiware.dart';
 import 'package:kepler_app/libs/preferences.dart';
 import 'package:kepler_app/libs/snack.dart';
@@ -51,6 +52,9 @@ import 'package:kepler_app/tabs/hourtable/pages/your_plan.dart'
     show generateExamInfoDialog, generateLessonInfoDialog;
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:provider/provider.dart';
+
+/// wie viel soll die Stundenplan-Liste weiter scrollbar sein, als echt nötig wäre - für "Ereignis hinzufügen"-Knopf
+const kSPListExtraScrollSpace = 32.0;
 
 enum SPDisplayMode {
   /// "Dein/Ihr Stundenplan": Stundenplan für einzelne, ausgewählte Klasse, Fächer können ausgeblendet werden.
@@ -687,6 +691,7 @@ class _StuPlanDayDisplayState extends State<StuPlanDayDisplay> {
                           ),
                         );
                       }
+                      if (Provider.of<Preferences>(context, listen: false).showYourPlanAddEvents) list.add(SizedBox(height: kSPListExtraScrollSpace));
                       return ListView(
                         shrinkWrap: true,
                         children: list,
@@ -707,6 +712,7 @@ class _StuPlanDayDisplayState extends State<StuPlanDayDisplay> {
                             ),
                           );
                         }
+                        if (Provider.of<Preferences>(context, listen: false).showYourPlanAddEvents) list.add(SizedBox(height: kSPListExtraScrollSpace));
                         return ListView.separated(
                           itemCount: list.length,
                           shrinkWrap: true,
@@ -715,18 +721,24 @@ class _StuPlanDayDisplayState extends State<StuPlanDayDisplay> {
                         );
                       }(),
                     )
-                  : LessonListContainer(
-                    lessons,
-                    widget.selected,
-                    widget.date,
-                    onSwipeLeft: widget.onSwipeLeft,
-                    onSwipeRight: widget.onSwipeRight,
-                    isOnline: isOnline,
-                    mode: widget.mode,
-                    fullLessonListForDate: allLessonsForDate,
-                    onRefresh: () async {
-                      showSnackBar(text: await loadData(forceRefresh: true) ? "Stundenplan für den aktuellen Tag erfolgreich aktualisiert." : "Aktualisieren gescheitert.", duration: const Duration(seconds: 2));
-                    },
+                  : Consumer<CustomEventManager>(
+                    builder: (context, evtmgr, _) {
+                      return LessonListContainer(
+                        lessons,
+                        widget.selected,
+                        widget.date,
+                        onSwipeLeft: widget.onSwipeLeft,
+                        onSwipeRight: widget.onSwipeRight,
+                        isOnline: isOnline,
+                        mode: widget.mode,
+                        fullLessonListForDate: allLessonsForDate,
+                        onRefresh: () async {
+                          showSnackBar(text: await loadData(forceRefresh: true) ? "Stundenplan für den aktuellen Tag erfolgreich aktualisiert." : "Aktualisieren gescheitert.", duration: const Duration(seconds: 2));
+                        },
+                        events: evtmgr.events.where((evt) => isSameDate(evt.startTime, widget.date)).toList(),
+                        extraScrollSpace: kSPListExtraScrollSpace,
+                      );
+                    }
                   ),
           ),
         ),
@@ -1227,7 +1239,69 @@ class SPListContainer extends StatelessWidget {
                       borderRadius: BorderRadius.circular(prefs.stuPlanDataAvailableBorderWidth > 5 ? 0 : 8),
                       color: color ?? Theme.of(context).colorScheme.surface,
                     ),
-                    child: subChild,
+                    child: subChild != null && prefs.showYourPlanAddEvents ? Stack(
+                      // mainAxisSize: MainAxisSize.min,
+                      children: [
+                        // Expanded(child: subChild),
+                        subChild,
+                        // Divider(indent: 32, endIndent: 32, color: hasDarkTheme(context) ? colorWithLightness(Colors.grey, .15) : null),
+                        Align(
+                          alignment: Alignment.bottomCenter,
+                          child: Transform.translate(
+                            offset: Offset(0, 4),
+                            child: Padding(
+                              // padding: const EdgeInsets.only(bottom: 8),
+                              padding: const EdgeInsets.only(),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  // /// Abstand auf beiden Seiten ausbalancieren, damit ElevatedButton in der Mitte bleibt
+                                  // const IconButton(icon: Icon(Icons.abc, size: 20, color: Colors.transparent), onPressed: null),
+                                  ElevatedButton(
+                                    onPressed: () {
+                                    },
+                                    style: ElevatedButton.styleFrom(
+                                      elevation: 0,
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.only(topLeft: Radius.circular(5), topRight: Radius.circular(5)),
+                                      ),
+                                      visualDensity: VisualDensity(vertical: -1),
+                                    ),
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        Flexible(
+                                          child: Padding(
+                                            padding: const EdgeInsets.only(right: 4),
+                                            child: const Icon(Icons.event, size: 16),
+                                          ),
+                                        ),
+                                        Flexible(flex: 0, child: Text("Ereignis hinzufügen")),
+                                      ],
+                                    ),
+                                  ),
+                                  // IconButton(onPressed: () {
+                                  //   showDialog(context: context, builder: (ctx) => AlertDialog(
+                                  //     title: const Text("Ausblenden?"),
+                                  //     content: const Text("Soll die Möglichkeit zum Hinzufügen von Ereignissen wirklich ausgeblendet werden? Dies kann jederzeit in den Einstellungen geändert werden."),
+                                  //     actions: [
+                                  //       TextButton(onPressed: () {
+                                  //         prefs.showYourPlanAddEvents = false;
+                                  //         Navigator.pop(ctx);
+                                  //       }, child: const Text("Ja, ausblenden")),
+                                  //       TextButton(onPressed: () {
+                                  //         Navigator.pop(ctx);
+                                  //       }, child: const Text("Nein")),
+                                  //     ],
+                                  //   ));
+                                  // }, icon: const Icon(Icons.visibility_off), iconSize: 20),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ) : subChild,
                   ),
                 ),
               );
@@ -1246,6 +1320,7 @@ class SPListContainer extends StatelessWidget {
 class LessonListContainer extends StatelessWidget {
   final List<VPLesson>? lessons;
   final List<VPLesson>? fullLessonListForDate;
+  final List<CustomEvent>? events;
   final String className;
   final DateTime date;
   final void Function()? onSwipeLeft;
@@ -1253,63 +1328,135 @@ class LessonListContainer extends StatelessWidget {
   final Future<void> Function() onRefresh;
   final bool? isOnline;
   final SPDisplayMode? mode;
-  const LessonListContainer(this.lessons, this.className, this.date, {super.key, this.onSwipeLeft, this.onSwipeRight, this.isOnline, this.mode, required this.fullLessonListForDate, required this.onRefresh});
+  /// wie viel soll die Liste weiter scrollbar sein, als echt nötig wäre - für "Ereignis hinzufügen"-Knopf
+  final double? extraScrollSpace;
+  LessonListContainer(
+    this.lessons,
+    this.className,
+    this.date, {
+    super.key,
+    this.onSwipeLeft,
+    this.onSwipeRight,
+    this.isOnline,
+    this.mode,
+    required this.fullLessonListForDate,
+    required this.onRefresh,
+    this.events,
+    this.extraScrollSpace,
+  }) {
+    events!.sort((a, b) {
+      if (a.startLesson != null && b.startLesson != null) return a.startLesson!.compareTo(b.startLesson!);
+      if (a.startLesson != null) return 1;
+      if (b.startLesson != null) return -1;
+      return a.startTime.compareTo(b.startTime);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return SPListContainer(
-        onSwipeLeft: onSwipeLeft,
-        onSwipeRight: onSwipeRight,
-        showBorder: lessons != null,
-        child: () {
-          if (lessons == null) {
-            return Center(
-              child: Text(
-                isOnline != false ? "Keine Daten verfügbar." : "Keine Verbindung zum Server.",
-                style: const TextStyle(fontSize: 18),
-              ),
-            );
-          }
-          if (lessons!.isEmpty) {
-            return Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    "${getDayDescription(date)} kein Unterricht${mode == SPDisplayMode.roomPlan ? " in diesem Raum" : mode == SPDisplayMode.classPlan ? " in dieser Klasse" : ""}.",
-                    style: const TextStyle(fontSize: 18),
-                    textAlign: TextAlign.center,
-                  ),
-                ]
-              ),
-            );
-          }
-          final stdata = Provider.of<StuPlanData>(context, listen: false);
-          return Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            child: RefreshIndicator(
-              onRefresh: onRefresh,
-              child: ListView.separated(
-                itemCount: lessons!.length,
-                itemBuilder: (context, index) => LessonDisplay(
-                  lessons![index],
-                  index > 0
-                      ? lessons!.elementAtOrNull(index - 1)?.schoolHour
-                      : null,
-                  fullLessonListForDate != null ? lessons![index].hasLastRoomUsageFromList(fullLessonListForDate!) : false,
-                  subject: stdata.availableSubjects[className]
-                      ?.cast<VPCSubjectS?>()
-                      .firstWhere(
-                        (s) => s!.subjectID == lessons![index].subjectID,
-                        orElse: () => null,
-                      ),
-                  classNameToStrip: className,
-                ),
-                separatorBuilder: (context, index) => const Divider(height: 24),
-              ),
-            ),
+      onSwipeLeft: onSwipeLeft,
+      onSwipeRight: onSwipeRight,
+      showBorder: lessons != null,
+      child: () {
+        if (lessons == null || lessons!.isEmpty) {
+          final infoText = Text(
+            lessons == null ? (isOnline != false ? "Keine Daten verfügbar." : "Keine Verbindung zum Server.")
+              : "${getDayDescription(date)} kein Unterricht${mode == SPDisplayMode.roomPlan ? " in diesem Raum" : mode == SPDisplayMode.classPlan ? " in dieser Klasse" : ""}.",
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: lessons == null ? hasDarkTheme(context) ? Colors.red.shade300 : Colors.red.shade800 : null),
           );
-        }());
+          if (events == null || events!.isEmpty) {
+            return Center(child: infoText);
+          } else {
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: ListView.separated(
+                itemCount: (events?.length ?? 0) + 2,
+                itemBuilder: (_, i) {
+                  if (i == 0) {
+                    return infoText;
+                  } else if (i == 1) {
+                    return Text(
+                      "Events ${getDayDescription(date).toLowerCase()}:",
+                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+                    );
+                  } else {
+                    return CustomEventDisplay(events![i - 2], i > 2 ? events![i - 3].startLesson ?? -1 : -1);
+                  }
+                },
+                separatorBuilder: (_, __) => const Divider(),
+              ),
+            );
+          }
+        }
+        final stdata = Provider.of<StuPlanData>(context, listen: false);
+
+        final mixedList = <Object>[...lessons!];
+        /// Events werden nur im persönlichen Stundenplan angezeigt
+        if (mode == SPDisplayMode.yourPlan && events != null && events!.isNotEmpty) {
+          var insI = 0;
+          var lastHr = 0;
+          // var lastStartIns = 0;
+          for (final evt in events!) {
+            if (evt.startLesson == null) {
+              // mixedList.insert(lastStartIns, evt);
+              // lastStartIns++;
+              mixedList.add(evt);
+              continue;
+            }
+            if (lastHr > 0 && evt.startLesson == lastHr) {
+              mixedList.insert(insI, evt);
+              insI++;
+            } else {
+              while (lessons![insI].schoolHour <= evt.startLesson!) {
+                insI++;
+              }
+              lastHr = evt.startLesson!;
+              mixedList.insert(insI, evt);
+              insI++;
+            }
+          }
+        }
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: RefreshIndicator(
+            onRefresh: onRefresh,
+            child: ListView.separated(
+              itemCount: mixedList.length + (extraScrollSpace != null ? 1 : 0),
+              itemBuilder: (context, index) {
+                if (index == mixedList.length) return SizedBox(height: extraScrollSpace);
+
+                final entry = mixedList[index];
+                final prevHour = index > 0 ? (){
+                  final p = mixedList[index - 1];
+                  return (p is VPLesson) ? p.schoolHour : (p is CustomEvent) ? (p.startLesson ?? -1) : -1;
+                }() : null;
+
+                if (entry is VPLesson) {
+                  return LessonDisplay(
+                    entry,
+                    prevHour,
+                    fullLessonListForDate != null ? entry.hasLastRoomUsageFromList(fullLessonListForDate!) : false,
+                    subject: stdata.availableSubjects[className]
+                        ?.cast<VPCSubjectS?>()
+                        .firstWhere(
+                          (s) => s!.subjectID == entry.subjectID,
+                          orElse: () => null,
+                        ),
+                    classNameToStrip: className,
+                  );
+                } else if (entry is CustomEvent) {
+                  return CustomEventDisplay(entry, prevHour);
+                } else {
+                  return SizedBox.shrink();
+                }
+              },
+              separatorBuilder: (context, index) => index < mixedList.length - 1 ? const Divider(height: 24) : const SizedBox.shrink(),
+            ),
+          ),
+        );
+      }(),
+    );
   }
 }
 
@@ -1343,20 +1490,23 @@ class LessonDisplay extends StatelessWidget {
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: (showInfoDialog)
-            ? () => showDialog(
-                context: context,
-                builder: (dialogCtx) => generateLessonInfoDialog(dialogCtx, lesson, subject, classNameToStrip, lastRoomUsageInDay))
-            : null,
+          ? () => showDialog(
+            context: context,
+            builder: (dialogCtx) => generateLessonInfoDialog(dialogCtx, lesson, subject, classNameToStrip, lastRoomUsageInDay),
+          ) : null,
         child: Column(
           children: [
             Row(
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
-                SizedBox(
-                  width: 26,
-                  child: (previousLessonHour != lesson.schoolHour)
-                      ? Text("${lesson.schoolHour}. ")
-                      : const SizedBox.shrink(),
+                Padding(
+                  padding: const EdgeInsets.only(right: 4),
+                  child: SizedBox(
+                    width: 26,
+                    child: (previousLessonHour != lesson.schoolHour)
+                        ? Text("${lesson.schoolHour}. ")
+                        : const SizedBox.shrink(),
+                  ),
                 ),
                 Text(
                   lesson.subjectCode.replaceFirst(classNameToStrip ?? "funny joke.", ""),
@@ -1406,7 +1556,7 @@ class LessonDisplay extends StatelessWidget {
             if (lesson.infoText != "")
               Row(
                 children: [
-                  const SizedBox(width: 25),
+                  const SizedBox(width: 25 + 4),
                   Flexible(
                     child: Text(
                       lesson.infoText,
@@ -1483,4 +1633,4 @@ class ExamDisplay extends StatelessWidget {
   }
 }
 
-// boah. fast 1500 Zeilen "Code".
+// boah. mehr als 1600 Zeilen "Code".

--- a/lib/tabs/hourtable/pages/plan_display.dart
+++ b/lib/tabs/hourtable/pages/plan_display.dart
@@ -1350,11 +1350,17 @@ class LessonListContainer extends StatelessWidget {
       if (a.date != null && b.date != null) {
         if (!isSameDate(a.date!, b.date!)) return a.date!.compareTo(b.date!);
 
-        if (a.startTime != null && b.startTime != null) return a.startTime!.compareTo(b.startTime!);
+        if (a.startTime != null && b.startTime != null) {
+          if (a.startTime == b.startTime) return a.title.compareTo(b.title);
+          return a.startTime!.compareTo(b.startTime!);
+        }
 
-        if (a.startLesson != null && b.startLesson != null) return a.startLesson!.compareTo(b.startLesson!);
-        if (a.startLesson != null) return 1;
-        if (b.startLesson != null) return -1;
+        if (a.startLesson != null && b.startLesson != null) {
+          if (a.startLesson == b.startLesson) return a.title.compareTo(b.title);
+          return a.startLesson!.compareTo(b.startLesson!);
+        }
+        if (a.startLesson != null) return -1;
+        if (b.startLesson != null) return 1;
       }
       return 0;
     });
@@ -1404,9 +1410,9 @@ class LessonListContainer extends StatelessWidget {
         final mixedList = <Object>[...lessons!];
         int hourAt(int i) {
           final o = mixedList[i];
-          if (o is CustomEvent) return o.startLesson ?? -1;
+          if (o is CustomEvent) return o.startLesson ?? 1000;
           if (o is VPLesson) return o.schoolHour;
-          return -1;
+          return 1000;
         }
         /// Events werden nur im persönlichen Stundenplan angezeigt
         if (mode == SPDisplayMode.yourPlan && events != null && events!.isNotEmpty) {
@@ -1424,7 +1430,7 @@ class LessonListContainer extends StatelessWidget {
               mixedList.insert(insI, evt);
               insI++;
             } else {
-              while (insI < lessons!.length && hourAt(insI) <= evt.startLesson!) {
+              while (insI < mixedList.length && hourAt(insI) <= evt.startLesson!) {
                 insI++;
               }
               lastHr = evt.startLesson!;

--- a/lib/tabs/hourtable/pages/plan_display.dart
+++ b/lib/tabs/hourtable/pages/plan_display.dart
@@ -32,6 +32,7 @@
 // kepler_app erhalten haben. Wenn nicht, siehe <https://www.gnu.org/licenses/>.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -51,6 +52,7 @@ import 'package:kepler_app/tabs/hourtable/pages/free_rooms.dart';
 import 'package:kepler_app/tabs/hourtable/pages/your_plan.dart'
     show generateExamInfoDialog, generateLessonInfoDialog;
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
 /// wie viel soll die Stundenplan-Liste weiter scrollbar sein, als echt nötig wäre - für "Ereignis hinzufügen"-Knopf
@@ -1269,6 +1271,19 @@ class SPListContainer extends StatelessWidget {
                                   onPressed: () async {
                                     final event = await showModifyEventDialog(context, addEventSelectedDate ?? DateTime.now());
                                     if (event != null) {
+                                      if (event.shouldNotify && Platform.isAndroid && !(await Permission.scheduleExactAlarm.isGranted)) {
+                                        if (!context.mounted) return;
+                                        await showDialog(context: context, builder: (ctx) => AlertDialog(
+                                          title: Text("Pünktliche Benachrichtigungen"),
+                                          content: Selector<Preferences, bool>(
+                                            selector: (ctx, prefs) => prefs.preferredPronoun == Pronoun.sie,
+                                            builder: (ctx, sie, _) => Text("${sie ? "Sie verwenden" : "Du verwendest"} eine moderne Version von Android. Um die Erinnerung pünktlich anzeigen zu können, benötigt die App die Berechtigung dafür. Bitte ${sie ? "stimmen Sie" : "stimme"} dafür im folgenden Dialog zu."),
+                                          ),
+                                          actions: [
+                                            TextButton(onPressed: () => Navigator.pop(ctx), child: Text("Abschließen")),
+                                          ],
+                                        ));
+                                      }
                                       if (!context.mounted) return;
                                       Provider.of<CustomEventManager>(context, listen: false).addEvent(event);
                                     }

--- a/lib/tabs/hourtable/pages/your_plan.dart
+++ b/lib/tabs/hourtable/pages/your_plan.dart
@@ -315,6 +315,8 @@ Future<bool> stuPlanShowInfoDialog(BuildContext context) async {
 
 // TODO: Dialog-Funktionen verschieben -> werden nur in plan_display.dart verwendet
 
+// TODO: Dialoge stattdessen als Popup-Panels von unten erstellen
+
 /// Dialog mit mehr Infos zu einer Stunde erstellen
 Widget generateLessonInfoDialog(BuildContext context, VPLesson lesson, VPCSubjectS? subject, String? classNameToReplace, bool lastRoomUsageInDay) {
   // TODO: Knopf zum Erstellen von Event für diese Schulstunde an diesem Tag hinzufügen

--- a/lib/tabs/hourtable/pages/your_plan.dart
+++ b/lib/tabs/hourtable/pages/your_plan.dart
@@ -58,8 +58,8 @@ class YourPlanPage extends StatefulWidget {
 }
 
 class YourPlanPageState extends State<YourPlanPage> {
-  /// gerade ausgewählter Plan, bestehend aus ( id* + 1, Klassenname/Lehrerkürzel )
-  /// *wenn id = 0 -> primärer Plan, sonst stdata.altSelectedClassNames[id - 1]
+  /// gerade ausgewählter Plan, bestehend aus ( id, Klassenname/Lehrerkürzel )
+  /// wenn id = 0 -> primärer Plan, sonst stdata.altSelectedClassNames[id - 1]
   /// 
   /// -> Achtung: bei Verwendung als Index immer `- 1` rechnen!
   late (int, String) selected;
@@ -184,6 +184,22 @@ class YourPlanPageState extends State<YourPlanPage> {
                 ),
               ],
             ),
+            // Align(
+            //   alignment: Alignment.bottomRight,
+            //   child: Padding(
+            //     padding: const EdgeInsets.all(16),
+            //     child: Container(
+            //       decoration: BoxDecoration(
+            //         boxShadow: [BoxShadow(blurRadius: 15, spreadRadius: -10, offset: Offset(2, 2))]
+            //       ),
+            //       child: FloatingActionButton(
+            //         elevation: 0,
+            //         onPressed: () {}, // add calendar entry
+            //         child: Icon(Icons.add),
+            //       ),
+            //     ),
+            //   ),
+            // ),
           ],
         );
       }

--- a/lib/tabs/hourtable/pages/your_plan.dart
+++ b/lib/tabs/hourtable/pages/your_plan.dart
@@ -317,6 +317,7 @@ Future<bool> stuPlanShowInfoDialog(BuildContext context) async {
 
 /// Dialog mit mehr Infos zu einer Stunde erstellen
 Widget generateLessonInfoDialog(BuildContext context, VPLesson lesson, VPCSubjectS? subject, String? classNameToReplace, bool lastRoomUsageInDay) {
+  // TODO: Knopf zum Erstellen von Event für diese Schulstunde an diesem Tag hinzufügen
   return AlertDialog(
     title: Text("Infos zur ${lesson.schoolHour}. Stunde"),
     content: DefaultTextStyle.merge(

--- a/lib/tabs/settings.dart
+++ b/lib/tabs/settings.dart
@@ -380,6 +380,13 @@ class _SettingsTabState extends State<SettingsTab> {
                   description: Text("aktivieren, um auf Seite \"${sie ? "Ihr" : "Dein"} Stundenplan\" Stundenpläne hinzufügen können"),
                   enabled: userType != UserType.nobody && Provider.of<StuPlanData>(context, listen: false).altSelectedClassNames.isEmpty,
                 ),
+                rainbowSwitchTile(
+                  initialValue: prefs.showYourPlanAddEvents,
+                  onToggle: (val) => prefs.showYourPlanAddEvents = val,
+                  title: const Text("Knopf für Ereignisse hinzufügen anzeigen"),
+                  description: Text("aktivieren, um auf Seite \"${sie ? "Ihr" : "Dein"} Stundenplan\" eigene Ereignisse hinzufügen können"),
+                  enabled: userType != UserType.nobody,
+                ),
               ],
             ),
             /// da die Kategorie LernSax selbst nur so wenig Inhalt hat, gibt es auch kaum Einstellungen

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  datetime_picker_formfield_new:
+    dependency: "direct main"
+    description:
+      name: datetime_picker_formfield_new
+      sha256: "04e353b959fa9f2654bb41ec016100152bdcd0afdef7b7b74a83d7d97bdba0a3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   dbus:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -306,26 +306,26 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "49eeef364fddb71515bc78d5a8c51435a68bccd6e4d68e25a942c5e47761ae71"
+      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.3"
+    version: "18.0.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
+      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
+      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "8.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -396,6 +396,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: "6e6a0a9d0dfc049b209e01e1dee3efd5ff2ddf2375e9de86589761b244eb5a5f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -911,13 +919,13 @@ packages:
     source: hosted
     version: "0.7.3"
   timezone:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: timezone
-      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      sha256: ffc9d5f4d1193534ef051f9254063fa53d588609418c84299956c3db9383587d
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4"
+    version: "0.10.0"
   typed_data:
     dependency: transitive
     description:
@@ -999,7 +1007,7 @@ packages:
     source: hosted
     version: "3.1.2"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ dependencies:
       ref: main
 
   # notification lib
-  flutter_local_notifications: ^17.2.1+2
+  flutter_local_notifications: ^18.0.1
 
   # icon lib
   material_design_icons_flutter: ^7.0.7296
@@ -133,6 +133,9 @@ dependencies:
 
   # libs for events
   datetime_picker_formfield_new: ^2.1.0
+  timezone: ^0.10.0
+  flutter_timezone: ^4.0.0
+  uuid: ^4.5.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 2.9.2+75
 
 environment:
-  sdk: '^3.0.0'
+  sdk: '^3.2.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -100,6 +100,7 @@ dependencies:
   enough_serialization: ^1.4.0
   flutter_secure_storage: ^9.2.1
   synchronized: ^3.1.0+1 # saving data to files
+  file_picker: ^8.1.4
 
   # libs for meal tab
   appcheck: ^1.5.2
@@ -129,7 +130,9 @@ dependencies:
   # libs for calendar
   calendar_date_picker2: ^1.0.2
   rainbow_color: ^2.0.1
-  file_picker: ^8.1.4
+
+  # libs for events
+  datetime_picker_formfield_new: ^2.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Man soll selbst Events (= Einträge/Termine im Stundenplan) hinzufügen können.

Mögliche Features:

- [x] Events für Schulstunden oder Zeitstunden
- [x] Events wie Stunden im Stundenplan anzeigen, wenn an Schulstunde gebunden
- [x] Events separat (am Ende der Liste? in extra Block?) anzeigen, wenn an Zeitstunden gebunden
- [ ] Wiederholbare Events (bzw. Events x Mal wiederholt erstellen), Änderungen für alle wenn gewünscht
- [x] Kurz vor Event Benutzer benachrichtigen (wenn gewünscht)