### PR TITLE
Added new rooms, fix for stuplan loading

### DIFF
--- a/lib/tabs/hourtable/pages/free_rooms.dart
+++ b/lib/tabs/hourtable/pages/free_rooms.dart
@@ -49,10 +49,10 @@ import 'package:kepler_app/libs/preferences.dart';
 final allKeplerRooms = [
   "K10", "K12",
   ...rooms("0", 1, 7, [2]), "021",
-  ...rooms("1", 7, 17, [13, 14, 15, 16]),
-  ...rooms("2", 1, 19, [6, 12, 14, 15, 16, 17]),
+  ...rooms("1", 7, 17, [14]),
+  ...rooms("2", 1, 19, [6, 12, 15, 16]),
   ...rooms("3", 1, 17, [3, 7, 14, 16]),
-  "TH", "Jb1", "Jb2",
+  "013TH", "Jb1", "Jb2",
 ];
 /// Varianten für Räume, Einteilung für Benutzer
 enum RoomType {
@@ -75,8 +75,8 @@ enum RoomType {
 final specialRoomInfo = {
   RoomType.compSci: ["K10", "K12", "202"],
   RoomType.technic: ["001", "021"],
-  RoomType.sports: ["TH", "Jb1", "Jb2"],
-  RoomType.specialist: ["112", "117", "213", "218", "313", "315"],
+  RoomType.sports: ["013TH", "Jb1", "Jb2"],
+  RoomType.specialist: ["112", "113", "115", "116", "117", "213", "214", "217", "218", "219", "313", "315"],
   RoomType.music: ["317"],
   RoomType.art: ["302"],
 };

--- a/lib/tabs/hourtable/pages/plan_display.dart
+++ b/lib/tabs/hourtable/pages/plan_display.dart
@@ -680,7 +680,12 @@ class _StuPlanDayDisplayState extends State<StuPlanDayDisplay> {
                               padding: const EdgeInsets.all(8.0),
                               child: SizedBox(height: 32, width: 32, child: CircularProgressIndicator(color: keplerColorBlue)),
                             ),
-                            Text("Lädt Stundenplan für ${DateFormat("dd.MM.").format(widget.date)}${info != null ? " ($info)" : ""}..."),
+                            Expanded(
+                              child:Text(
+                                "Lädt Stundenplan für ${DateFormat("dd.MM.").format(widget.date)}${info != null ? " ($info)" : ""}",
+                                maxLines : 2,
+                              ),
+                            ),
                           ],
                         ),
                       ),

--- a/lib/tabs/hourtable/pages/plan_display.dart
+++ b/lib/tabs/hourtable/pages/plan_display.dart
@@ -681,9 +681,9 @@ class _StuPlanDayDisplayState extends State<StuPlanDayDisplay> {
                               child: SizedBox(height: 32, width: 32, child: CircularProgressIndicator(color: keplerColorBlue)),
                             ),
                             Expanded(
-                              child:Text(
+                              child: Text(
                                 "Lädt Stundenplan für ${DateFormat("dd.MM.").format(widget.date)}${info != null ? " ($info)" : ""}",
-                                maxLines : 2,
+                                maxLines: 2,
                               ),
                             ),
                           ],


### PR DESCRIPTION
added rooms from the new building
renamed TH to 013TH because of the system
fixed pixel overflow in the new stuplan loading

Die Turnhalle ist jetzt auch gleichzeitig Raum 013. Im StuPlan ist ersichtlich, dass das zusammengezogen als 013TH verwendet wird.
evtl. wäre es für die Benutzerfreundlichkeit sinnvoll, 013TH an allen Stellen, an denen der Raum angezeigt wird, nur als TH anzuzeigen.
Entgegen meiner Information sind die neuen Räume doch schon in Benutzung, diese habe ich jetzt auch hinzugefügt (immernoch ohne 100%ige Sicherheit).
